### PR TITLE
Sort out bullet points and indenting, fixes #7

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -63,8 +63,15 @@ section {
         }
     }
 
+    ol li {
+        list-style-type: decimal;
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+
     li {
-        list-style-position: inside;
+        margin: 1em;
+        list-style-position: outside;
         list-style-type: disc;
     }
 }
@@ -140,4 +147,8 @@ section {
 
 .post-description {
     line-height: 1.25em;
+}
+
+.highlight {
+    margin: 1em;
 }

--- a/development/index.md
+++ b/development/index.md
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Development 
- 
 ---
 
 ### Contributing to BOUT++
@@ -36,11 +35,9 @@ Here are some rules for editing the core BOUT++ code:
    use a little Fortran now and then, please please don’t put any into BOUT++.
    Use of Fortran, particularly when mixed with C/C++, is the cause of many
    problems in porting and modifying codes.
-
 -  If a feature is needed to study a particular system, only include it in the
    core code if it is more generally applicable, or cannot be put into the
    physics module.
-
 -  If you add a new feature, function, class member, etc. you must also include
    doxygen comments that explain what each new thing does. Similarly, if a change
    you make would affect e.g. a function's arguments, please ensure that you keep
@@ -48,6 +45,7 @@ Here are some rules for editing the core BOUT++ code:
    for best practices in this regard. If you submit a pull request that doesn't
    add or update documentation where appropriate, we may ask you to do so before
    it is merged.
+
 
 ### Development workflow using Git
 
@@ -155,11 +153,8 @@ rather than **how**.
 For documenting what functions and classes do, we use [Doxygen][doxygen].
 
 - Prefer C++ style comments `//` over C style `/* */`
-
-- Doxygen comments: use `///`.
-
+- Doxygen comments: use `///`.  
   Doxygen done right:
-
   ``` cpp
   /// Foo the bar
   ///
@@ -176,7 +171,6 @@ For documenting what functions and classes do, we use [Doxygen][doxygen].
   /// @returns true on success
   bool applyFoo(BoutReal bar, int quux, std::vector<int> &result);
   ```
-
 - The header files are essentially the "public" API, so prefer to put
   Doxygen comments there, rather than in the implementation. "Private"
   functions, etc., can be documented in the implementation.

--- a/publications/index.md
+++ b/publications/index.md
@@ -7,9 +7,9 @@ nav-state: publications
 ### Publications
 
 
-* L Easy,  F Militello, J Omotani, B Dudson, E Havlickova, P Tamain, V Naulin, A H Nielsen [3D Simulations of Plasma Filaments in the Scrape Off Layer: A Comparison with Models of Reduced Dimensionality](http://dx.doi.org/10.1063/1.4904207) Phys. Plasmas 21, 122515 (2014). [arXiv preprint](http://arxiv.org/abs/1410.2137)  
+* L Easy,  F Militello, J Omotani, B Dudson, E Havlickova, P Tamain, V Naulin, A H Nielsen [3D Simulations of Plasma Filaments in the Scrape Off Layer: A Comparison with Models of Reduced Dimensionality](http://dx.doi.org/10.1063/1.4904207) Phys. Plasmas 21, 122515 (2014). [arXiv preprint](http://arxiv.org/abs/1410.2137)
 
-* D Meyerson, C Michoski, F Waelbroeck, W Horton [Effect of chaos on plasma filament dynamics and turbulence in the scrape-off layer](http://dx.doi.org/10.1063/1.4890349) Phys. Plasmas 21, 072310 (2014)  
+* D Meyerson, C Michoski, F Waelbroeck, W Horton [Effect of chaos on plasma filament dynamics and turbulence in the scrape-off layer](http://dx.doi.org/10.1063/1.4890349) Phys. Plasmas 21, 072310 (2014)
 
 * B D Dudson, A.Allen, G.Breyiannis, E.Brugger, J.Buchanan, L.Easy, S.Farley, I.Joseph, M. Kim, A.D.McGann, J.T.Omotani, M.V.Umansky, N.R.Walkden, T.Xia, X.Q.Xu [BOUT++: Recent and current developments](http://dx.doi.org/10.1017/S0022377814000816) Journal of Plasma Physics 2014. [arXiv preprint](http://arxiv.org/abs/1405.7905)
 


### PR DESCRIPTION
Remove new lines between list items to make kramdown not put item inside a paragraph tag

Also tweak CSS to make lists and code blocks indented, and numbered lists use numbers