### PR TITLE
Fix broken links on applications page

### DIFF
--- a/_applications/06-two-phase-flow.md
+++ b/_applications/06-two-phase-flow.md
@@ -4,7 +4,9 @@ image:
 caption: 
 ---
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Ewi01r_h2J0" frameborder="0" allowfullscreen></iframe>
+<div class="video-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/Ewi01r_h2J0" frameborder="0" allowfullscreen></iframe>
+</div>
 
 Incompressible flow in 2D of two fluids with different densities and viscosities. 
 Buoyancy is included, but not surface tension (yet).

--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,19 @@ gems:
 - jekyll-paginate
 exclude:
 - vendor
+collections:
+  applications:
+    output: true
+    permalink: /applications/:title
+defaults:
+  # Defaults for applications collection
+  - scope:
+      path: ""
+      type: applications
+    values:
+      layout: applications
+      excerpt_separator: <!--more-->
+
+# Config for running site locally
 localtest: false
 localurl: http://localhost:4000/
-collections:
-  - applications

--- a/_layouts/applications.html
+++ b/_layouts/applications.html
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+
+<div class="section">
+  <br>
+  <section class="v100">
+    <br>
+    <div>
+      <h2 class="center-align blue-text">{{ page.title }}</h2>
+    </div>
+    <div class="divider"></div>
+    <div class="container container-wide markdown-file">
+
+      <ul class="collection with-header">
+        <div class="row">
+          <li class="collection-item" style="list-style-type: none;">
+            <div class="left">
+              <img class="responsive-img materialboxed" src="{{ page.image }}" data-caption="{{ page.caption }}">
+            </div>
+            <span class="flow-text">{{ page.content }}</span>
+          </li>
+        </div>
+      </ul>
+    </div>
+  </section>
+</div>

--- a/applications/index.html
+++ b/applications/index.html
@@ -30,7 +30,7 @@ please contact <a href="mailto:peter.hill@york.ac.uk">Peter Hill</a> or other BO
                   <img class="responsive-img materialboxed" src="{{ post.image }}" data-caption="{{ post.caption }}">
                 </div>
               </div>
-              <span class="flow-text">{{ post.content }}</span>
+              <span class="flow-text">{{ post.excerpt }}</span>
             </li>
           </div>
         </ul>

--- a/applications/index.html
+++ b/applications/index.html
@@ -25,7 +25,11 @@ please contact <a href="mailto:peter.hill@york.ac.uk">Peter Hill</a> or other BO
           </li>
           <div class="row">
             <li class="collection-item" style="list-style-type: none;">
-              <img class="materialboxed" style="text-align: center;" src="{{ post.image }}" data-caption="{{ post.caption }}">
+              <div style="text-align: center;">
+                <div style="display: inline-block;">
+                  <img class="responsive-img materialboxed" src="{{ post.image }}" data-caption="{{ post.caption }}">
+                </div>
+              </div>
               <span class="flow-text">{{ post.content }}</span>
             </li>
           </div>


### PR DESCRIPTION
Also make the images centred, and allow more content on full page.

Add extra content in markdown file after a `<!--more-->` HTML comment. This extra content doesn't appear in the full list, but does appear on the stand-alone page.