### PR TITLE
Override screen size to stop navbar text overlapping

### DIFF
--- a/assets/css/materialize.scss
+++ b/assets/css/materialize.scss
@@ -9,6 +9,19 @@
 // Variables;
 @import "components/variables";
 
+// Override screen sizes so navbar text doesn't overlap
+$small-screen-up: 601px;
+$medium-screen-up: 1321px;
+$large-screen-up: 1400px;
+$small-screen: 600px;
+$medium-screen: 1320px;
+$large-screen: 1400px;
+
+// Need to restate these here to pick up the new values above
+$large-and-up: "only screen and (min-width : #{$medium-screen-up})";
+$medium-and-down: "only screen and (max-width : #{$medium-screen})";
+$medium-only: "only screen and (min-width : #{$small-screen-up}) and (max-width : #{$medium-screen})";
+
 // Reset
 @import "components/normalize";
 


### PR DESCRIPTION
Fixes #28 

This means that the top menu gets hidden on screens smaller than 1320 -- might be a problem on widescreen laptops? These are the values to play about with, at any rate.