### PR TITLE
Update ffi dependency to version 1.9.24

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
-    ffi (1.9.14)
+    ffi (1.9.24)
     forwardable-extended (2.6.0)
     jekyll (3.3.1)
       addressable (~> 2.4)


### PR DESCRIPTION
Current version ffi 1.9.14 has security vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2018-1000201

This updates dependency to 1.9.24.