### PR TITLE
Remove "Register now"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,7 +20,6 @@
 	    {% if item.title == "Workshop 2018" %}
 	      <p class="banner_advert">
               {{ item.title }}
-	      REGISTER NOW!
 	      </p>
 	      </b>
 	      </a>


### PR DESCRIPTION
Remove "Register now" from website banner, but keep bold link to workshop page.