### PR TITLE
Use "BOUT++" not "BOUT++ Project" in banner head

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 ---
 title: BOUT++ Project
+short_title: BOUT++
 author: BOUT++ Project
 author_github: boutproject
 locale: en

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 
 <nav class="blue accent-3" role="navigation">
   <div class="container">
-    <div class="nav-wrapper"><a id="logo-container" href="{{ site.github.url }}" class="brand-logo">{{ site.title }}</a>
+    <div class="nav-wrapper"><a id="logo-container" href="{{ site.github.url }}" class="brand-logo">{{ site.short_title }}</a>
       <a href="#" data-activates="mobile-menu" class="button-collapse"><i class="material-icons">menu</i></a>
         <ul class="right hide-on-med-and-down">
           {% for item in site.data.navigation %}


### PR DESCRIPTION
Introduce `short_title` variable in the config file for the short form of the project name.  Also use this in the  banner head, so it reads "BOUT++" instead of "BOUT++ Project".

I've added a second variable rather than change `title`, because it gives more flexibility. I think "BOUT++ Project" looks better than just "BOUT++" in the main centre box. 