### PR TITLE
Don't say that 4.0.0 is the latest release

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -18,7 +18,7 @@ The latest release is always available from [here][latest].
 
 Previous releases are available:
 
-* [Version 4.0.0][v4.0.0], was realeased 4th February 2017.
+* [Version 4.0.0][v4.0.0], was released 4th February 2017.
 * [Version 3.0][v3.0], prepared for the [2015 BOUT++ workshop](../documentation/workshop2015.html)
 * [Version 2.0][v2.0], prepared for the [2013 BOUT++ workshop](https://bout2013.llnl.gov/)
 * [Version 1.0][v1.0], prepared for the [2011 BOUT++ workshop](https://bout2011.llnl.gov/)

--- a/download/index.md
+++ b/download/index.md
@@ -18,8 +18,18 @@ The latest release is always available from [here][latest].
 
 Previous releases are available:
 
+* [Version 4.2.3][v4.2.3], was released 23rd October 2017.
+* [Version 4.2.2][v4.2.2], was released 1st March 2019.
+* [Version 4.2.1][v4.2.1], was released 23rd January 2019.
+* [Version 4.2.0][v4.2.0], was released 17th October 2018.
+* [Version 4.1.2][v4.1.2], was released 1st December 2017.
+* [Version 4.1.1][v4.1.1], was released 18th October 2017.
+* [Version 4.1.0][v4.1.0], was released 22nd September 2017.
+* [Version 4.0.1][v4.0.1], was released 22nd September 2017.
 * [Version 4.0.0][v4.0.0], was released 4th February 2017.
+* [Version 3.1][v3.1], was released 31st January 2017.
 * [Version 3.0][v3.0], prepared for the [2015 BOUT++ workshop](../documentation/workshop2015.html)
+* [Version 2.1][v2.1], was released 4th December 2015
 * [Version 2.0][v2.0], prepared for the [2013 BOUT++ workshop](https://bout2013.llnl.gov/)
 * [Version 1.0][v1.0], prepared for the [2011 BOUT++ workshop](https://bout2011.llnl.gov/)
 
@@ -30,7 +40,17 @@ Previous releases are available:
 
 [latest]: https://github.com/boutproject/BOUT-dev/releases/latest
 [development]: https://github.com/boutproject/BOUT-dev/tree/next
+[v4.2.3]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.2.3
+[v4.2.2]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.2.2
+[v4.2.1]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.2.1
+[v4.2.0]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.2.0
+[v4.1.2]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.1.2
+[v4.1.1]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.1.1
+[v4.1.0]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.1.0
+[v4.0.1]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.0.1
 [v4.0.0]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.0.0
+[v3.1]: https://github.com/boutproject/BOUT-dev/releases/tag/v3.1
 [v3.0]: https://github.com/boutproject/BOUT-dev/releases/tag/v3.0
+[v2.1]: https://github.com/boutproject/BOUT-dev/releases/tag/v2.1
 [v2.0]: https://github.com/boutproject/BOUT-dev/releases/tag/v2.0
 [v1.0]: https://github.com/boutproject/BOUT-dev/releases/tag/v1.0

--- a/download/index.md
+++ b/download/index.md
@@ -18,7 +18,7 @@ The latest release is always available from [here][latest].
 
 Previous releases are available:
 
-* The latest release, [version 4.0.0][v4.0.0], was realeased 4th February 2017.
+* [Version 4.0.0][v4.0.0], was realeased 4th February 2017.
 * [Version 3.0][v3.0], prepared for the [2015 BOUT++ workshop](../documentation/workshop2015.html)
 * [Version 2.0][v2.0], prepared for the [2013 BOUT++ workshop](https://bout2013.llnl.gov/)
 * [Version 1.0][v1.0], prepared for the [2011 BOUT++ workshop](https://bout2011.llnl.gov/)

--- a/download/index.md
+++ b/download/index.md
@@ -18,6 +18,7 @@ The latest release is always available from [here][latest].
 
 Previous releases are available:
 
+* [Version 4.3.0][v4.3.0], was released 25th October 2017.
 * [Version 4.2.3][v4.2.3], was released 23rd October 2017.
 * [Version 4.2.2][v4.2.2], was released 1st March 2019.
 * [Version 4.2.1][v4.2.1], was released 23rd January 2019.
@@ -40,6 +41,7 @@ Previous releases are available:
 
 [latest]: https://github.com/boutproject/BOUT-dev/releases/latest
 [development]: https://github.com/boutproject/BOUT-dev/tree/next
+[v4.3.0]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.3.0
 [v4.2.3]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.2.3
 [v4.2.2]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.2.2
 [v4.2.1]: https://github.com/boutproject/BOUT-dev/releases/tag/v4.2.1


### PR DESCRIPTION
Not adding a version avoids having to patch this website after every release