### PR TITLE
Fix typo in v4.3.0 release post

### DIFF
--- a/_posts/2019-10-25-v4.3.0_released.md
+++ b/_posts/2019-10-25-v4.3.0_released.md
@@ -3,7 +3,7 @@ layout: post
 title: BOUT++ v4.3.0 released!
 categories: announcement
 author: Peter Hill
-description: New feature release: BOUT++ v4.3.0!
+description: New feature release -- BOUT++ v4.3.0!
 url: /v4-3-0-released/
 tags: releases
 ---


### PR DESCRIPTION
Can't have colons in descriptions