### PR TITLE
Rename documentation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,7 +6,8 @@ sections:
     applications: /applications
     publications: /publications
   documentation:
-    documentation: /documentation
+    documentation: //bout-dev.readthedocs.io/en/latest/
     development: /development
+    getting help: /documentation
   download: /download
   Workshop 2019: /documentation/workshop2019.html

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Documentation
+title: Getting Help
 description: Where to find documentation and get help for BOUT++
 nav-state: documentation
 ---


### PR DESCRIPTION
The Documentation should link to the full manual.
The old documentation link is rather how to get further help.

I have accidentally also pushed to other commits 72543f44511939b028e0b71cf9c7f59f6bd093f3 and f7a58241a25610f554e7671c6b923db7b793e31f, which where intended for https://dschwoerer.github.io/boutproject.github.io/ for testing.

Should we protect master, so that this cannot happen again?

f7a58241a25610f554e7671c6b923db7b793e31f fix #26 
72543f44511939b028e0b71cf9c7f59f6bd093f3 should be part of this PR.
The links at https://dschwoerer.github.io/boutproject.github.io/ are broken, because the website is  not in the root of the domain, but that shouldn't be an issue at https://boutproject.github.io/

I haven't reverted them, as they seem to work.