### PR TITLE
Update kramdown version in response to github recommendation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       jekyll (~> 3.3)
     jekyll-watch (2.1.2)
       listen (~> 3.0)
-    kramdown (1.17.0)
+    kramdown (2.3.0)
     liquid (4.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)


### PR DESCRIPTION
Github dependabot reporting that kramdown < 2.3.0 is insecure. We probably don't really care as it's a static site hosted on github itself, but also good to address if we can. I've not tested the website build locally with the version as I'm not able to build the site (I don't know how at least).