### PR TITLE
Bump jekyll version to fix dependency alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source 'https://rubygems.org'
-gem 'jekyll', ">= 3.6.3"
+gem 'jekyll', ">= 3.9.0"
 gem 'jekyll-paginate'
 gem 'jekyll-sass-converter'
 gem 'sass'
 gem 'jekyll-compose', group: [:jekyll_plugins]
 gem 'jekyll-seo-tag'
+gem 'kramdown-parser-gfm'
 #gem 'github-pages', group: [:jekyll_plugins]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.4)
-    em-websocket (0.5.1)
+    concurrent-ruby (1.1.9)
+    em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    ffi (1.10.0)
+    ffi (1.15.3)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.5)
+    jekyll (3.9.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
       i18n (~> 0.7)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 1.14)
+      kramdown (>= 1.17, < 3)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
@@ -34,25 +34,27 @@ GEM
       sass (~> 3.4)
     jekyll-seo-tag (2.1.0)
       jekyll (~> 3.3)
-    jekyll-watch (2.1.2)
+    jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.0)
-    liquid (4.0.1)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
+    kramdown (2.3.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.3)
+    listen (3.5.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (3.0.3)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
+    public_suffix (4.0.6)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rouge (3.3.0)
-    ruby_dep (1.5.0)
-    safe_yaml (1.0.4)
-    sass (3.7.3)
+    rexml (3.2.5)
+    rouge (3.26.0)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -62,12 +64,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (>= 3.6.3)
+  jekyll (>= 3.9.0)
   jekyll-compose
   jekyll-paginate
   jekyll-sass-converter
   jekyll-seo-tag
+  kramdown-parser-gfm
   sass
 
 BUNDLED WITH
-   1.16.1
+   1.17.2


### PR DESCRIPTION
These aren't real problems, but it will shut up dependabot